### PR TITLE
Prevent URLs which can only fail from making calls to the service

### DIFF
--- a/src/checkmatelib/client.py
+++ b/src/checkmatelib/client.py
@@ -5,7 +5,7 @@ from future.utils import raise_from  # Python 2.7 compatibility
 
 try:
     from urllib.parse import urlparse
-except ImportError:
+except ImportError:  # pragma: no cover
     # Python 2.7 compatibility
     from urlparse import urlparse
 

--- a/tests/unit/checkmatelib/client_test.py
+++ b/tests/unit/checkmatelib/client_test.py
@@ -53,6 +53,11 @@ class TestCheckmateClient:
         with pytest.raises(CheckmateException):
             client.check_url("http://bad.example.com")
 
+    @pytest.mark.parametrize("url", ("http://", "/", "http:///", "http:///path", "/"))
+    def test_it_with_bad_urls(self, client, url):
+        with pytest.raises(BadURL):
+            client.check_url(url)
+
     @pytest.fixture
     def client(self):
         return CheckmateClient(host="http://checkmate.example.com/")


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/27

This introduces a small delay, but will be much faster than making a call which will fail.