### PR TITLE
Truncate long URLs to prevent them from ending up as 400's

### DIFF
--- a/src/checkmatelib/client.py
+++ b/src/checkmatelib/client.py
@@ -12,6 +12,8 @@ from checkmatelib.exceptions import CheckmateServiceError, handles_request_error
 class CheckmateClient:
     """A client for the Checkmate URL testing service."""
 
+    MAX_URL_LENGTH = 2000
+
     def __init__(self, host):
         """Initialise a client for contacting the Checkmate service.
 
@@ -30,6 +32,9 @@ class CheckmateClient:
         :return: None if the URL is fine or a `CheckmateResponse` if there are
            reasons to block the URL.
         """
+
+        # Truncate extremely long URLs so we don't get 400's and fail open
+        url = url[: self.MAX_URL_LENGTH]
 
         response = requests.get(
             self._host + "/api/check", params={"url": url}, timeout=1

--- a/tests/unit/checkmatelib/client_test.py
+++ b/tests/unit/checkmatelib/client_test.py
@@ -53,6 +53,17 @@ class TestCheckmateClient:
         with pytest.raises(CheckmateException):
             client.check_url("http://bad.example.com")
 
+    def test_it_truncates_very_long_urls(self, client, requests):
+        very_long_url = "http://" + "a" * 10000
+
+        client.check_url(very_long_url)
+
+        _, kwargs = requests.get.call_args
+
+        called_url = kwargs["params"]["url"]
+        assert len(called_url) == client.MAX_URL_LENGTH
+        assert called_url == very_long_url[: client.MAX_URL_LENGTH]
+
     @pytest.fixture
     def client(self):
         return CheckmateClient(host="http://checkmate.example.com/")


### PR DESCRIPTION
This prevents extremely long URLs from evading our checks on the domain, which really only need the first X chars to apply.