### PR TITLE
Add allow_all support

### DIFF
--- a/src/checkmatelib/client.py
+++ b/src/checkmatelib/client.py
@@ -22,13 +22,16 @@ class CheckmateClient:
         self._host = host.rstrip("/")
 
     @handles_request_errors
-    def check_url(self, url):
+    def check_url(self, url, allow_all=False):
         """Check a URL for reasons to block.
 
         :param url: URL to check
+        :param allow_all: If True, bypass Checkmate's allow-list
+
         :raises BadURL: If the provided URL is bad
         :raises CheckmateServiceError: If there is a problem contacting the service
         :raises CheckmateException: For any other issue with the Checkmate service
+
         :return: None if the URL is fine or a `CheckmateResponse` if there are
            reasons to block the URL.
         """
@@ -36,9 +39,12 @@ class CheckmateClient:
         # Truncate extremely long URLs so we don't get 400's and fail open
         url = url[: self.MAX_URL_LENGTH]
 
-        response = requests.get(
-            self._host + "/api/check", params={"url": url}, timeout=1
-        )
+        params = {"url": url}
+
+        if allow_all:
+            params["allow_all"] = True
+
+        response = requests.get(self._host + "/api/check", params=params, timeout=1)
 
         response.raise_for_status()
 

--- a/tests/unit/checkmatelib/client_test.py
+++ b/tests/unit/checkmatelib/client_test.py
@@ -28,6 +28,11 @@ class TestCheckmateClient:
         assert hits == BlockResponse.return_value
         BlockResponse.assert_called_once_with(response.json.return_value)
 
+    def test_allow_all(self, client, requests):
+        client.check_url("http://bad.example.com", allow_all=True)
+
+        assert requests.get.call_args[1]["params"].get("allow_all")
+
     @pytest.mark.parametrize(
         "exception,expected",
         (


### PR DESCRIPTION
Add support for bypassing Checkmate's allow-list by sending the `allow_all` param.