### PR TITLE
Extract the presentation URL from checkmate responses

### DIFF
--- a/src/checkmatelib/_response.py
+++ b/src/checkmatelib/_response.py
@@ -27,6 +27,11 @@ class BlockResponse:
         self._payload = payload
 
     @property
+    def presentation_url(self):
+        """Get a URL to display this error in HTML."""
+        return self._payload["links"]["html"]
+
+    @property
     def reason_codes(self):
         """Get the list of reason codes."""
         return [reason["id"] for reason in self._payload["data"]]

--- a/src/checkmatelib/resource/response_schema.json
+++ b/src/checkmatelib/resource/response_schema.json
@@ -5,7 +5,7 @@
     "$comment": "This schema only enforces the parts we care about and lets the rest drift.",
 
     "type": "object",
-    "required": ["data"],
+    "required": ["data", "links"],
     "additionalProperties": true,
 
     "properties": {
@@ -22,6 +22,15 @@
                     "id": {"type": "string"}
                 }
             }
+        },
+        "links": {
+            "type": "object",
+            "required": ["html"],
+            "additionalProperties": true,
+
+            "properties": {
+                "html": {"type": "string", "format": "uri"}
+            }
         }
     },
 
@@ -34,7 +43,10 @@
                     "attributes": {"severity": "mandatory"}
                 }
             ],
-            "meta": {"maxSeverity": "mandatory"}
+            "meta": {"maxSeverity": "mandatory"},
+            "links": {
+                "html": "http://checkmate.example.com/view_error"
+            }
         }
     ]
 }

--- a/tests/unit/checkmatelib/_response_test.py
+++ b/tests/unit/checkmatelib/_response_test.py
@@ -14,6 +14,7 @@ class TestBlockResponse:
         response = BlockResponse(payload)
 
         assert response.reason_codes == ["reason_1", "reason_2"]
+        assert response.presentation_url == payload["links"]["html"]
 
     @pytest.mark.parametrize(
         "payload",
@@ -41,5 +42,9 @@ class TestBlockResponse:
         return {
             "data": [{"id": "reason_1", "noise": "random_noise"}, {"id": "reason_2"}],
             "meta": {"maxSeverity": "very_bad", "noise": "random_noise"},
+            "links": {
+                "html": "http://checkmate.example.com/display_error",
+                "noise": "random_noise",
+            },
             "noise": "random_noise",
         }


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/15

This cannot be merged until https://github.com/hypothesis/checkmate/pull/148 is deployed. It wouldn't do anything immediately, but if we got a dependabot request to update our products it could cause trouble.

This parses the `links.html` response from Checkmate and makes is available to callers.