### PR TITLE
Api auth in checkmatelib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ help:
 	@echo "make initialrelease    Create the first release of a package"
 	@echo "make test              Run the unit tests"
 	@echo "make coverage          Print the unit test coverage report"
+	@echo "make sure              Make sure that the formatter, linter, tests, etc all pass"
 	@echo "make clean             Delete development artefacts (cached files, "
 	@echo "                       dependencies, etc)"
 	@echo "make template          Replay the cookiecutter project template over this"
@@ -41,6 +42,9 @@ initialrelease: python
 .PHONY: test
 test: python
 	@tox -qe tests,py27-tests
+
+.PHONY: sure
+sure: checkformatting lint test
 
 .PHONY: coverage
 coverage: python

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ from checkmatelib import CheckmateClient, CheckmateException
 
 client = CheckmateClient("http://checkmate.example.com")
 try:
-    hits = client.check_url("http://bad.example.com")
+    hits = client.check_url("http://bad.example.com", "YOUR_CHECKMATE_API_KEY")
    
 except CheckmateException:
     ...   # To block or not to block?

--- a/src/checkmatelib/client.py
+++ b/src/checkmatelib/client.py
@@ -14,12 +14,17 @@ class CheckmateClient:
 
     MAX_URL_LENGTH = 2000
 
-    def __init__(self, host):
+    def __init__(self, host, api_key):
         """Initialise a client for contacting the Checkmate service.
 
+        CHECKMATE_API_KEY must be present to configure authentication
+
         :param host: The host including scheme, for the Checkmate service
+        :param api_key: API key for Checkmate
         """
         self._host = host.rstrip("/")
+
+        self._api_key = api_key
 
     @handles_request_errors
     def check_url(self, url, allow_all=False):
@@ -44,7 +49,12 @@ class CheckmateClient:
         if allow_all:
             params["allow_all"] = True
 
-        response = requests.get(self._host + "/api/check", params=params, timeout=1)
+        response = requests.get(
+            self._host + "/api/check",
+            params=params,
+            timeout=1,
+            auth=(self._api_key,) if self._api_key else None,
+        )
 
         response.raise_for_status()
 

--- a/tests/unit/checkmatelib/client_test.py
+++ b/tests/unit/checkmatelib/client_test.py
@@ -23,6 +23,7 @@ class TestCheckmateClient:
             "http://checkmate.example.com/api/check",
             params={"url": "http://bad.example.com"},
             timeout=1,
+            auth=("API_KEY",),
         )
 
         assert hits == BlockResponse.return_value
@@ -71,7 +72,7 @@ class TestCheckmateClient:
 
     @pytest.fixture
     def client(self):
-        return CheckmateClient(host="http://checkmate.example.com/")
+        return CheckmateClient(host="http://checkmate.example.com/", api_key="API_KEY")
 
     @pytest.fixture
     def response(self, requests):


### PR DESCRIPTION
Just sending the http auth if present.

This could be merged and install in clients independently of the server PR status.