### PR TITLE
Use a two elements tuple for requests auth param.

### DIFF
--- a/src/checkmatelib/client.py
+++ b/src/checkmatelib/client.py
@@ -53,7 +53,7 @@ class CheckmateClient:
             self._host + "/api/check",
             params=params,
             timeout=1,
-            auth=(self._api_key,) if self._api_key else None,
+            auth=(self._api_key, "") if self._api_key else None,
         )
 
         response.raise_for_status()

--- a/tests/unit/checkmatelib/client_test.py
+++ b/tests/unit/checkmatelib/client_test.py
@@ -23,7 +23,7 @@ class TestCheckmateClient:
             "http://checkmate.example.com/api/check",
             params={"url": "http://bad.example.com"},
             timeout=1,
-            auth=("API_KEY",),
+            auth=("API_KEY", ""),
         )
 
         assert hits == BlockResponse.return_value


### PR DESCRIPTION
Although checkmate only requires to pass the api key as the username
requests `auth=` requires a two element tuple.