### PR TITLE
Pass ignore reasons to checkmate

### DIFF
--- a/src/checkmatelib/client.py
+++ b/src/checkmatelib/client.py
@@ -28,13 +28,14 @@ class CheckmateClient:
 
     @handles_request_errors
     def check_url(  # pylint: disable=inconsistent-return-statements
-        self, url, allow_all=False, blocked_for=None
+        self, url, allow_all=False, blocked_for=None, ignore_reasons=None
     ):
         """Check a URL for reasons to block.
 
         :param url: URL to check
         :param allow_all: If True, bypass Checkmate's allow-list
         :param blocked_for: Sets a context for the blocked pages layout/content
+        :param ignore_reasons: Ignore this class of detections. Comma separated reasons.
 
         :raises BadURL: If the provided URL is bad
         :raises CheckmateServiceError: If there is a problem contacting the service
@@ -54,6 +55,9 @@ class CheckmateClient:
 
         if blocked_for:
             params["blocked_for"] = blocked_for
+
+        if ignore_reasons:
+            params["ignore_reasons"] = ignore_reasons
 
         response = requests.get(
             self._host + "/api/check",

--- a/tests/unit/checkmatelib/client_test.py
+++ b/tests/unit/checkmatelib/client_test.py
@@ -39,6 +39,12 @@ class TestCheckmateClient:
 
         assert requests.get.call_args[1]["params"].get("blocked_for")
 
+    def test_ignore_reasons(self, client, requests):
+        reasons = "reason1,reason2"
+        client.check_url("http://bad.example.com", ignore_reasons=reasons)
+
+        assert requests.get.call_args[1]["params"]["ignore_reasons"] == reasons
+
     @pytest.mark.parametrize(
         "exception,expected",
         (


### PR DESCRIPTION
Detections that match any of the ignored_reasons passed will be filtered out server side.

The parameter it's a list of comma separated strings but I think that's fine as the value will (for now) set on a env var and won't change that often.

