### PR TITLE
Use `pip-tox-sync` instead of `pip-tox-extension`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,10 @@ envlist = tests
 skipsdist = true
 minversion = 3.8.0
 requires =
-  tox-pip-extensions
+  tox-pip-sync
   tox-pyenv
   tox-envfile
   tox-run-command
-tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false
 
 [testenv]


### PR DESCRIPTION
For: https://github.com/hypothesis/tox-pip-sync/issues/5

I chose `checkmatelib` as a test bed for using `tox-pip-sync` in a library as:

 * It uses Python 2 which makes it the hardest case
 * It's used by the fewest products `['viahtml', 'via3']` (joint with `pyramid-sanity`: `['h', 'checkmate']`)

It looks to me like the local install dependency `.[tests]` is not working. Which is causing multiple things to fail.

~**Don't merge!** - This looks fine in CI, because we don't go through `tox` but it's totally hosed locally
This requires: https://github.com/hypothesis/tox-pip-sync/pull/7~

## Testing notes

 * `rm .tox -rf`
 * `make sure`