### PR TITLE
Remove deprecated importlib methods and fix lint issues

### DIFF
--- a/src/checkmatelib/_response.py
+++ b/src/checkmatelib/_response.py
@@ -13,9 +13,10 @@ class BlockResponse:
 
     VALIDATOR = Draft7Validator(
         json.loads(
-            importlib_resources.read_binary(
-                "checkmatelib.resource", "response_schema.json"
-            )
+            (
+                importlib_resources.files("checkmatelib.resource")
+                / "response_schema.json"
+            ).read_bytes()
         )
     )
 
@@ -26,7 +27,7 @@ class BlockResponse:
         :param payload: Decoded JSON response from the Checkmate service.
         """
         for error in self.VALIDATOR.iter_errors(payload):
-            raise CheckmateException("Unparseable response: {}".format(error))
+            raise CheckmateException(f"Unparseable response: {error}")
 
         self._payload = payload
 
@@ -41,4 +42,4 @@ class BlockResponse:
         return [reason["id"] for reason in self._payload["data"]]
 
     def __repr__(self):
-        return "BlockResponse({})".format(repr(self._payload))
+        return f"BlockResponse({repr(self._payload)})"

--- a/tests/unit/checkmatelib/_response_test.py
+++ b/tests/unit/checkmatelib/_response_test.py
@@ -35,7 +35,7 @@ class TestBlockResponse:
     def test_it_stringifies(self, payload):
         response = BlockResponse(payload)
 
-        assert repr(response) == "BlockResponse({})".format(payload)
+        assert repr(response) == f"BlockResponse({payload})"
 
     @pytest.fixture
     def payload(self):


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/via/pull/652

`read_binary()` has been deprecated. As we don't pin our dependencies in our libs, this has shown up in another product under a dependabot PR.

So this removes the usage, and also fixes some lint issues (due to newer linting) as well.